### PR TITLE
add more control during scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Changes in this fork
-Variable Bit Rate added to allow for controlling the quality of NVENC
-Threshold and Ceiling for scanning for both Bit Rate and Height of the video, allow to selectively pick which files to add to the encode list
-Add commands for clearing the different lists of files
+Variable Bit Rate added to allow for controlling the quality of NVENC  
+Threshold and Ceiling for scanning for both Bit Rate and Height of the video, allow to selectively pick which files to add to the encode list  
+Add commands for clearing the different lists of files  
 Skipped file list of files which did not meet the thresholds or ceilings, to allow to be easily purged when ready to change parameters
 
 # x265-converter

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Transcoded:
     --number NUMBER, -n NUMBER
                             transcode from tracked paths limit number of files to be converted
     --nvenc               transcode using NVENC compatable GPU
+    --resolution
     --preset PRESET       string for ffmpeg paramater, accepts ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow and placebo, slower speeds have a higher filesize and better quality
     --track PATH, -t PATH
                             add a new path to be tracked

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Changes in this fork
+Variable Bit Rate added to allow for controlling the quality of NVENC
+Threshold and Ceiling for scanning for both Bit Rate and Height of the video, allow to selectively pick which files to add to the encode list
+Add commands for clearing the different lists of files
+Skipped file list of files which did not meet the thresholds or ceilings, to allow to be easily purged when ready to change parameters
+
 # x265-converter
 A database focused media conversion utility that converts video files to the
 HEVC video codec with a focus on reducing disk usage in media libraries. This
@@ -40,7 +46,7 @@ Transcoded:
     --number NUMBER, -n NUMBER
                             transcode from tracked paths limit number of files to be converted
     --nvenc               transcode using NVENC compatable GPU
-    --height               Height of the output resolution to be used for conversion
+    --height              Height of the output resolution to be used for conversion
     --preset PRESET       string for ffmpeg paramater, accepts ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow and placebo, slower speeds have a higher filesize and better quality
     --track PATH, -t PATH
                             add a new path to be tracked

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Transcoded:
     --number NUMBER, -n NUMBER
                             transcode from tracked paths limit number of files to be converted
     --nvenc               transcode using NVENC compatable GPU
-    --resolution
+    --height               Height of the output resolution to be used for conversion
     --preset PRESET       string for ffmpeg paramater, accepts ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow and placebo, slower speeds have a higher filesize and better quality
     --track PATH, -t PATH
                             add a new path to be tracked

--- a/README.md
+++ b/README.md
@@ -29,28 +29,55 @@ Transcoded:
 
 # example usage:
 
-    usage: main.py [-h] [--crf int] [--errors] [--database DATABASE] [--focus PATH] [--list-paths] [--low-profile] [--number NUMBER] [--nvenc] [--preset PRESET] [--track PATH] [--saved-space] [--scan] [--quiet] [--verbose]
+    usage: main.py [-h] [--crf int] [--errors] [--database DATABASE] [--focus PATH] [--list-paths] [--list-blacklist-paths] [--low-profile] [--number NUMBER]  
+                [--nvenc] [--height HEIGHT] [--preset PRESET] [--track PATH] [--blacklist PATH] [--saved-space] [--scan] [--quiet] [--verbose] [--vbr VBR]  
+                [--minrate MINRATE] [--maxrate MAXRATE] [--rate-threshold RATE_THRESHOLD] [--rate-ceiling RATE_CEILING] [--height-threshold HEIGHT_THRESHOLD]  
+                [--height-ceiling HEIGHT_CEILING] [--force-encode] [--clear-all] [--clear-skipped] [--clear-incomplete] [--clear-complete] [--clear-failed]  
 
-    A database focused media conversion utility that converts video files to the HEVC video codec with a focus on reducing disk usage in media libraries. This script attempts to be as safe as possible, however encoding to HEVC is a lossy operation. though it should be
-    unnoticable it is recommended to test first. Backups are encouraged.
+    A database focused media conversion utility that converts video files to the HEVC video codec with a focus on reducing disk usage in media libraries. This  
+    script attempts to be as safe as possible, however encoding to HEVC is a lossy operation. though it should be unnoticeable it is recommended to test first.  
+    Backups are encouraged.  
 
     optional arguments:
-    -h, --help            show this help message and exit
-    --crf int             CRF paramater to be passed through to ffmpeg, determines quality and speed with lower values being slower but higher quality
-    --errors, -e          list errors
-    --database DATABASE   name of database to be used
-    --focus PATH, -f PATH
-                            immediately begin conversion on target directory
-    --list-paths, -lp     list tracked paths
-    --low-profile         for weaker devices, convert to 4-bit HEVC including downgrading 10-bit hevc
-    --number NUMBER, -n NUMBER
-                            transcode from tracked paths limit number of files to be converted
-    --nvenc               transcode using NVENC compatable GPU
-    --height              Height of the output resolution to be used for conversion
-    --preset PRESET       string for ffmpeg paramater, accepts ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow and placebo, slower speeds have a higher filesize and better quality
-    --track PATH, -t PATH
-                            add a new path to be tracked
-    --saved-space         display HDD space saved by transcoding into x265
-    --scan, -s            scan tracked directories for new files
-    --quiet, -q           only produce minimal output
-    --verbose, -v         produce as much output as possible
+    -h, --help            show this help message and exit  
+    --crf int             CRF parameter to be passed through to ffmpeg, determines quality and speed with lower values being slower but higher quality (not  
+                            for NVENC)  
+    --errors, -e          list errors  
+    --database DATABASE   name of database to be used  
+    --focus PATH, -f PATH  
+                            immediately begin conversion on target directory  
+    --list-paths, -lp     list tracked paths  
+    --list-blacklist-paths, -lbp  
+                            list blacklisted paths  
+    --low-profile         for weaker devices, convert to 4-bit HEVC including downgrading 10-bit hevc  
+    --number NUMBER, -n NUMBER  
+                            transcode from tracked paths limit number of files to be converted  
+    --nvenc               transcode using NVENC compatible GPU  
+    --height HEIGHT       Height of the output resolution to be used for conversion  
+    --preset PRESET       string for ffmpeg paramater, accepts ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow and placebo,  
+                            slower speeds have a higher filesize and better quality  
+    --track PATH, -t PATH  
+                            add a new path to be tracked  
+    --blacklist PATH, -b PATH  
+                            add a blacklist path to be excluded from scans  
+    --saved-space         display HDD space saved by transcoding into x265  
+    --scan, -s            scan tracked directories for new files  
+    --quiet, -q           only produce minimal output  
+    --verbose, -v         produce as much output as possible  
+    --vbr VBR             Set the Variable Bitrate for the encoding pass, this will adjust NVENC quality  
+    --minrate MINRATE     Set the minimum rate for Variable Bitrate mode  
+    --maxrate MAXRATE     Set the maximum rate for Variable Bitrate mode  
+    --rate-threshold RATE_THRESHOLD  
+                            Set the minimum kbps files must have in order to add to processing list during scan  
+    --rate-ceiling RATE_CEILING  
+                            Set the maximum kbps files can have in order to add to processing list during scan  
+    --height-threshold HEIGHT_THRESHOLD  
+                            Set the minimum height files must have in order to add to processing list during scan  
+    --height-ceiling HEIGHT_CEILING  
+                            Set the maximum height files can have in order to add to processing list during scan  
+    --force-encode        force HEVC re-encode  
+    --clear-all           clear the library of all files  
+    --clear-skipped       clear the library of skipped files  
+    --clear-incomplete    clear the library of incomplete files  
+    --clear-complete      clear the library of complete files  
+    --clear-failed        clear the library of failed files  

--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ The latest version of ffmpeg is 4.1.4 when testing, download from [ffmpeg](https
     main.py -t /path/to/media -s
     main.py -n 10
 
+# usage for compression
+Both of these examples are utilizing the NVENC option, which will speed up the encoding process drastically
+
+Here we can use it to compress a video library to a smaller frame size, ensuring only to compress files which are not already low bitrate
+
+    main.py -t /path/to/media -s --height-threshold 1080 --rate-threshold 1000 --force-encode
+    main.py -n 10 --height 720 --nvenc --vbr 1000k --minrate 400k --maxrate 1600k
+
+Or use it to compress files with low resolution, making sure to only add files below SDTV
+
+    main.py -t /path/to/media -s --height-ceiling 480 --force-encode
+    main.py -n 10 --nvenc --vbr 300k --minrate 100k --maxrate 800k
+
 # comparison
 Original:
 ![original](https://github.com/formcore/x265-videoconverter/blob/master/video_examples_output/x264%20to%20x265%20original.png?raw=true)

--- a/library/mediaTracker.py
+++ b/library/mediaTracker.py
@@ -272,4 +272,4 @@ class MediaLibrary:
 
     def _libraryCommit(self):
         with open(self.libraryFilePath, "w") as jsonFile:
-            json.dump(self.library, jsonFile)
+            jsonFile.write(json.dumps(self.library,indent=2))

--- a/library/mediaTracker.py
+++ b/library/mediaTracker.py
@@ -123,6 +123,9 @@ class MediaLibrary:
            ffprobe them and add metadata to database."""
         self.log.info(f" MediaLibrary scanning {path}")
         for root, _, files in os.walk(path):
+            for blacklist_entry in self.library["blacklist"]:
+                if blacklist_entry in root:
+                    continue # this folder is within a blacklisted folder
             for name in files:
                 if str.lower(os.path.splitext(name)[1]) not in self.videoFileTypes:
                     continue  # not a video

--- a/library/mediaTracker.py
+++ b/library/mediaTracker.py
@@ -99,6 +99,8 @@ class MediaLibrary:
         self.height = False
         self.rate_threshold = False
         self.rate_ceiling = False
+        self.height_threshold = False
+        self.height_ceiling = False
         self.force_encode = False
         if args.verbose:
             self.log = logger.setup_logging(None, "DEBUG")
@@ -197,12 +199,18 @@ class MediaLibrary:
                     print(json.dumps(self.info.ffprobe, indent=2))
                     return
 
-                if (self.rate_threshold and self.entry["bit_rate"] <= self.rate_threshold ):
+                if (self.rate_threshold and self.entry["bit_rate"] < self.rate_threshold ):
                     self.library["skipped_files"][self.filepath] = self.entry
                     self.log.info(f'{self.entry["width"]}x{self.entry["height"]} @ {self.entry["bit_rate"]}kbps -- Skipping File, below the bit rate threshold')
-                elif (self.rate_ceiling and self.entry["bit_rate"] >= self.rate_ceiling ):
+                elif (self.rate_ceiling and self.entry["bit_rate"] > self.rate_ceiling ):
                     self.library["skipped_files"][self.filepath] = self.entry
                     self.log.info(f'{self.entry["width"]}x{self.entry["height"]} @ {self.entry["bit_rate"]}kbps -- Skipping File, above the bit rate ceiling')
+                elif (self.height_threshold and self.entry["height"] < self.height_threshold ):
+                    self.library["skipped_files"][self.filepath] = self.entry
+                    self.log.info(f'{self.entry["width"]}x{self.entry["height"]} @ {self.entry["bit_rate"]}kbps -- Skipping File, below the height threshold')
+                elif (self.height_ceiling and self.entry["height"] > self.height_ceiling ):
+                    self.library["skipped_files"][self.filepath] = self.entry
+                    self.log.info(f'{self.entry["width"]}x{self.entry["height"]} @ {self.entry["bit_rate"]}kbps -- Skipping File, above the height ceiling')
                 elif (self.info.isEncoded() and not self.force_encode):
                     self.library["complete_files"][self.filepath] = self.entry
                     self.library["complete_files"][self.filepath]["original_codec"] = "hevc"
@@ -276,6 +284,34 @@ class MediaLibrary:
         if self.mediaDirectory not in self.library["paths"]:
             self.log.info(f" Adding new scan path {self.mediaDirectory}")
             self.library["paths"].append(self.mediaDirectory)
+        self._libraryCommit()
+
+    def clearAll(self):
+        """Clear all file lists."""
+        self.library["skipped_files"] = {}
+        self.library["incomplete_files"] = {}
+        self.library["complete_files"] = {}
+        self.library["failed_files"] = {}
+        self._libraryCommit()
+
+    def clearSkipped(self):
+        """Clear the skipped file list."""
+        self.library["skipped_files"] = {}
+        self._libraryCommit()
+
+    def clearIncomplete(self):
+        """Clear the incomplete file list."""
+        self.library["incomplete_files"] = {}
+        self._libraryCommit()
+
+    def clearComplete(self):
+        """Clear the complete file list."""
+        self.library["complete_files"] = {}
+        self._libraryCommit()
+
+    def clearFailed(self):
+        """Clear the failed file list."""
+        self.library["failed_files"] = {}
         self._libraryCommit()
 
     def addBlacklistPath(self, filepath):

--- a/library/mediaTracker.py
+++ b/library/mediaTracker.py
@@ -64,6 +64,8 @@ class VideoInformation:
         self.entry = {}
         try:
             self.entry["video_codec"] = self.videoStreams[0]["codec_name"]
+            self.entry["height"] = self.videoStreams[0]["height"]
+            self.entry["width"] = self.videoStreams[0]["width"]
         except IndexError:
             self.log.error("No video streams")
             return False
@@ -92,6 +94,7 @@ class MediaLibrary:
             ".vob",
             ".webm",
             ".wmv",
+            ".m4v"
         ]
         if not os.path.exists(os.path.dirname(self.libraryFilePath)):
             os.makedirs(os.path.dirname(self.libraryFilePath), exist_ok=True)
@@ -99,6 +102,7 @@ class MediaLibrary:
             self.log.info(f" No medialibrary found, creating new library")
             self.library = {}
             self.library["paths"] = []
+            self.library["blacklist"] = []
             self.library["incomplete_files"] = {}
             self.library["complete_files"] = {}
             self.library["failed_files"] = {}
@@ -216,9 +220,24 @@ class MediaLibrary:
             self.library["paths"].append(self.mediaDirectory)
         self._libraryCommit()
 
+    def addBlacklistPath(self, filepath):
+        """Create a new blacklist path entry in library."""
+        self.mediaDirectory = os.path.abspath(filepath)
+        if not os.path.isdir(filepath):
+            self.log.error(f"invalid directory {filepath}")
+            sys.exit(2)
+        if self.mediaDirectory not in self.library["blacklist"]:
+            self.log.info(f" Adding new blacklist path {self.mediaDirectory}")
+            self.library["blacklist"].append(self.mediaDirectory)
+        self._libraryCommit()
+
     def listPaths(self):
         """List tracked paths stored in library."""
         return self.library["paths"]
+
+    def listBlacklistPaths(self):
+        """List blacklist paths stored in library."""
+        return self.library["blacklist"]
 
     def returnLibraryEntries(self, count):
         """Return a list of filepaths from the top of the database."""
@@ -266,4 +285,4 @@ class MediaLibrary:
 
     def _libraryCommit(self):
         with open(self.libraryFilePath, "w") as jsonFile:
-            json.dump(self.library, jsonFile)
+            jsonFile.write(json.dumps(self.library,indent=2))

--- a/library/mediaTracker.py
+++ b/library/mediaTracker.py
@@ -7,11 +7,16 @@ import subprocess
 from library import logger
 
 class VideoInformation:
-    def __init__(self, fp):
+    def __init__(self, fp, args):
         self.filepath = fp
         self.low_profile = False
-        self.resolution = False
-        self.log = logger.setup_logging()
+        self.height = False
+        if args.verbose:
+            self.log = logger.setup_logging(None, "DEBUG")
+        elif args.quiet:
+            self.log = logger.setup_logging(None, "CRITICAL")
+        else:
+            self.log = logger.setup_logging(None)        
 
     def analyze(self):
         self.command = [
@@ -56,7 +61,7 @@ class VideoInformation:
         for stream in self.videoStreams:
             if stream["codec_name"] != "hevc":
                 return False
-            elif self.resolution and stream["height"] != self.resolution:
+            elif self.height and stream["height"] != self.height:
                 return False
             elif stream["profile"] != "Main" and self.low_profile is True:
                 return False
@@ -78,14 +83,29 @@ class VideoInformation:
             self.entry["video_profile"] = ""
         self.entry["file_size"] = self.ffprobe["format"]["size"]
         self.entry["duration"] = int(float(self.ffprobe["format"]["duration"]))
-        self.entry["resolution"] = int(self.videoStreams[0]["height"])
         return self.entry
 
+    def advEntry(self):
+        try:
+            self.entry["bit_rate"] = int(self.ffprobe["format"]["bit_rate"]) / 1000
+        except IndexError:
+            self.entry["bit_rate"] = None
+            return False
+
+
 class MediaLibrary:
-    def __init__(self, databasePath):
+    def __init__(self, databasePath, args):
         self.low_profile = False
-        self.resolution = False
-        self.log = logger.setup_logging()
+        self.height = False
+        self.rate_threshold = False
+        self.rate_ceiling = False
+        self.force_encode = False
+        if args.verbose:
+            self.log = logger.setup_logging(None, "DEBUG")
+        elif args.quiet:
+            self.log = logger.setup_logging(None, "CRITICAL")
+        else:
+            self.log = logger.setup_logging(None)        
         self.libraryFilePath = (os.path.abspath(databasePath))
         self.videoFileTypes = [
             ".3gp",
@@ -110,6 +130,7 @@ class MediaLibrary:
             self.library["paths"] = []
             self.library["blacklist"] = []
             self.library["incomplete_files"] = {}
+            self.library["skipped_files"] = {}
             self.library["complete_files"] = {}
             self.library["failed_files"] = {}
             self.library["space_saved"] = 0
@@ -118,17 +139,23 @@ class MediaLibrary:
         with open(self.libraryFilePath) as jsonFile:
             self.library = json.load(jsonFile)
 
-    def scan(self, path):
+    def scan(self, path, args):
         """Searching through files in path that are not in database.
            ffprobe them and add metadata to database."""
         self.log.info(f" MediaLibrary scanning {path}")
         for root, _, files in os.walk(path):
+            root_valid = True
             for blacklist_entry in self.library["blacklist"]:
                 if blacklist_entry in root:
-                    continue # this folder is within a blacklisted folder
+                    self.log.debug( f'{root} is within blacklisted folder {blacklist_entry}')
+                    root_valid = False
+                    break
+            if not root_valid:
+                continue 
             for name in files:
                 if str.lower(os.path.splitext(name)[1]) not in self.videoFileTypes:
-                    continue  # not a video
+                    self.log.debug(f'{name} is not a video')
+                    continue
                 self.filepath = os.path.join(root, name)
 
                 if (
@@ -136,20 +163,24 @@ class MediaLibrary:
                     or self.filepath in self.library["complete_files"]
                     or self.filepath in self.library["failed_files"]
                 ):
-                    continue  # file is already tracked
+                    self.log.debug(f'{name} is already tracked')
+                    continue
+                if ( self.filepath in self.library["skipped_files"] ):
+                    self.log.debug(f'{name} is already skipped')
+                    continue
 
                 # Windows path limit. Fatal
                 if len(self.filepath) > 255:
                     continue
                 print(self.filepath)
 
-                self.info = VideoInformation(self.filepath)
+                self.info = VideoInformation(self.filepath,args)
                 self.info.low_profile = self.low_profile
-                self.info.resolution = self.resolution
+                self.info.height = self.height
                 self.analyzeResult = self.info.analyze()
                 if self.analyzeResult is False:
                     error = f"VideoInformation failed reading {self.filepath}"
-                    self.log.info(error)
+                    self.log.critical(error)
                     failedEntry = {}
                     failedEntry["filepath"] = self.filepath
                     failedEntry["errorMessage"] = error
@@ -160,12 +191,30 @@ class MediaLibrary:
                 except KeyError as error:
                     self.markFailed(self.filepath, error)
                     continue
-                if self.info.isEncoded():
+                try:
+                    self.info.advEntry()
+                except KeyError as error:
+                    print(json.dumps(self.info.ffprobe, indent=2))
+                    return
+
+                if (self.rate_threshold and self.entry["bit_rate"] <= self.rate_threshold ):
+                    self.library["skipped_files"][self.filepath] = self.entry
+                    self.log.info(f'{self.entry["width"]}x{self.entry["height"]} @ {self.entry["bit_rate"]}kbps -- Skipping File, below the bit rate threshold')
+                elif (self.rate_ceiling and self.entry["bit_rate"] >= self.rate_ceiling ):
+                    self.library["skipped_files"][self.filepath] = self.entry
+                    self.log.info(f'{self.entry["width"]}x{self.entry["height"]} @ {self.entry["bit_rate"]}kbps -- Skipping File, above the bit rate ceiling')
+                elif (self.info.isEncoded() and not self.force_encode):
                     self.library["complete_files"][self.filepath] = self.entry
                     self.library["complete_files"][self.filepath]["original_codec"] = "hevc"
                     self.library["complete_files"][self.filepath]["space_saved"] = 0
+                    self.log.debug(f'{self.entry["width"]}x{self.entry["height"]} @ {self.entry["bit_rate"]}kbps -- File is already encoded in HEVC')
+                elif (self.force_encode):
+                    self.library["incomplete_files"][self.filepath] = self.entry
+                    self.log.info(f'{self.entry["width"]}x{self.entry["height"]} @ {self.entry["bit_rate"]}kbps -- Adding to tracked list as forced HEVC re-encode')
                 else:
                     self.library["incomplete_files"][self.filepath] = self.entry
+                    self.log.info(f'{self.entry["width"]}x{self.entry["height"]} @ {self.entry["bit_rate"]}kbps -- Adding to tracked list')
+                
         self._libraryCommit()
         self.log.info("Scan completed")
 

--- a/library/videoEncoder.py
+++ b/library/videoEncoder.py
@@ -43,6 +43,7 @@ class X265Encoder:
 
         self.low_profile = False
         self.nvenc = False
+        self.resolution = False
         self.crf = 28
         self.preset = "medium"
 
@@ -199,6 +200,10 @@ class X265Encoder:
             self.log.debug("Main10 profile used")
             self.command += ["-profile:v", "main10"]
 
+        if self.resolution:
+            self.log.debug("Resolution used")
+            self.command += ["-vf", f"scale=-1:{self.resolution}"]
+
     def _restore(self):
         if os.path.exists(self.backupFilepath):
             if os.path.exists(self.outputFilepath):
@@ -238,6 +243,8 @@ class X265Encoder:
         self.file = mediaTracker.VideoInformation(self.filepath)
         if self.low_profile is True:
             self.file.low_profile = True
+        if self.resolution:
+            self.file.resolution = self.resolution
         self.file.analyze()
 
         if self.file.isEncoded():
@@ -272,7 +279,6 @@ class X265Encoder:
             os.remove(self.backupFilepath)
             return self.outputFilepath
 
-    
 class Error(Exception):
     pass
 

--- a/library/videoEncoder.py
+++ b/library/videoEncoder.py
@@ -44,7 +44,7 @@ class X265Encoder:
 
         self.low_profile = False
         self.nvenc = False
-        self.resolution = False
+        self.height = False
         self.crf = 28
         self.preset = "medium"
         self.vbr = False
@@ -212,9 +212,9 @@ class X265Encoder:
             self.log.debug("Main10 profile used")
             self.command += ["-profile:v", "main10"]
 
-        if self.resolution:
-            self.log.debug("Resolution used")
-            self.command += ["-vf", f"scale=-1:{self.resolution}"]
+        if self.height:
+            self.log.debug("Scaling to specified height")
+            self.command += ["-vf", f"scale=-1:{self.height}"]
 
     def _restore(self):
         if os.path.exists(self.backupFilepath):
@@ -255,8 +255,8 @@ class X265Encoder:
         self.file = mediaTracker.VideoInformation(self.filepath)
         if self.low_profile is True:
             self.file.low_profile = True
-        if self.resolution:
-            self.file.resolution = self.resolution
+        if self.height:
+            self.file.height = self.height
         self.file.analyze()
 
         if self.file.isEncoded():

--- a/library/videoEncoder.py
+++ b/library/videoEncoder.py
@@ -10,7 +10,7 @@ from library import mediaTracker
 from library import logger
 
 class X265Encoder:
-    def __init__(self, filepath):
+    def __init__(self, filepath, args):
 
         """
         wiki states that these file formats are HEVC compatable
@@ -51,7 +51,12 @@ class X265Encoder:
         self.minrate = False
         self.maxrate = False
 
-        self.log = logger.setup_logging()
+        if args.verbose:
+            self.log = logger.setup_logging(None, "DEBUG")
+        elif args.quiet:
+            self.log = logger.setup_logging(None, "CRITICAL")
+        else:
+            self.log = logger.setup_logging(None)        
 
     def _backup(self):
         if os.path.isfile(self.backupFilepath):
@@ -247,12 +252,12 @@ class X265Encoder:
             return False
         return True
 
-    def encode(self):
+    def encode(self, args):
 
         if not self._checkValid():
             raise InvalidFileError
 
-        self.file = mediaTracker.VideoInformation(self.filepath)
+        self.file = mediaTracker.VideoInformation(self.filepath, args)
         if self.low_profile is True:
             self.file.low_profile = True
         if self.height:

--- a/library/videoEncoder.py
+++ b/library/videoEncoder.py
@@ -9,6 +9,7 @@ import time
 from library import mediaTracker
 from library import logger
 
+
 class X265Encoder:
     def __init__(self, filepath, args):
 
@@ -293,9 +294,22 @@ class X265Encoder:
             self._restore()
             raise EncoderFailedError(ffmpegError)
         else:
-            time.sleep(2)
-            os.remove(self.backupFilepath)
+            passed = False
+            i = 0
+            while not passed:
+                i += 1
+                time.sleep(.2)
+                try:
+                    os.chmod(self.backupFilepath, 0o777)
+                    os.remove(self.backupFilepath)
+                    passed = True
+                except PermissionError as error:
+                    print(error)
+                    pass
+                if (i >= 10):
+                    sys.exit()
             return self.outputFilepath
+
 
 class Error(Exception):
     pass

--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ def main():
     parser.add_argument("--database", action="store", help="name of database to be used")
     parser.add_argument("--focus", "-f", action="append", metavar="PATH", help="immediately begin conversion on target directory")
     parser.add_argument("--list-paths", "-lp", action="store_true", help="list tracked paths")
-    parser.add_argument("--list-blacklist-paths", "-lp", action="store_true", help="list blacklisted paths")
+    parser.add_argument("--list-blacklist-paths", "-lbp", action="store_true", help="list blacklisted paths")
     parser.add_argument("--low-profile", action="store_true", help="for weaker devices, convert to 4-bit HEVC including downgrading 10-bit hevc", default=False)
     parser.add_argument("--number", "-n", action="store", help="transcode from tracked paths limit number of files to be converted", type=int)
     parser.add_argument("--nvenc", action="store_true", help="transcode using NVENC compatible GPU")
@@ -35,6 +35,7 @@ def main():
         help="string for ffmpeg paramater, accepts ultrafast, superfast, veryfast, faster, fast, medium, slow, slower,\
              veryslow and placebo, slower speeds have a higher filesize and better quality")
     parser.add_argument("--track", "-t", action="append", metavar="PATH", help="add a new path to be tracked")
+    parser.add_argument("--blacklist", "-b", action="append", metavar="PATH", help="add a blacklist path to be excluded from scans")
     parser.add_argument("--saved-space", action="store_true", help="display HDD space saved by transcoding into x265")
     parser.add_argument("--scan", "-s", action="store_true", help="scan tracked directories for new files")
     parser.add_argument("--quiet", "-q", action="store_true", help="only produce minimal output")
@@ -82,6 +83,10 @@ def main():
     if args.track:
         for path in args.track:
             library.addNewPath(os.path.abspath(path))
+
+    if args.blacklist:
+        for path in args.blacklist:
+            library.addBlacklistPath(os.path.abspath(path))
 
     if args.saved_space:
         totalSavedMB = int(library.returnTotalSaved() / 1_000_000)

--- a/main.py
+++ b/main.py
@@ -183,7 +183,7 @@ def main():
         except KeyError:
             continue
 
-        encoder = videoEncoder.X265Encoder(filepath)
+        encoder = videoEncoder.X265Encoder(filepath, args)
         if args.low_profile:
             encoder.low_profile = True
         if args.nvenc:
@@ -218,7 +218,7 @@ def main():
                 encoder.maxrate = args.maxrate
             
         try:
-            encodeResult = encoder.encode()
+            encodeResult = encoder.encode(args)
         except videoEncoder.AlreadyEncodedError:
             library.markComplete(filepath)
             continue

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ def main():
     parser.add_argument("--database", action="store", help="name of database to be used")
     parser.add_argument("--focus", "-f", action="append", metavar="PATH", help="immediately begin conversion on target directory")
     parser.add_argument("--list-paths", "-lp", action="store_true", help="list tracked paths")
+    parser.add_argument("--list-blacklist-paths", "-lp", action="store_true", help="list blacklisted paths")
     parser.add_argument("--low-profile", action="store_true", help="for weaker devices, convert to 4-bit HEVC including downgrading 10-bit hevc", default=False)
     parser.add_argument("--number", "-n", action="store", help="transcode from tracked paths limit number of files to be converted", type=int)
     parser.add_argument("--nvenc", action="store_true", help="transcode using NVENC compatable GPU")
@@ -37,6 +38,9 @@ def main():
     parser.add_argument("--scan", "-s", action="store_true", help="scan tracked directories for new files")
     parser.add_argument("--quiet", "-q", action="store_true", help="only produce minimal output")
     parser.add_argument("--verbose", "-v", action="store_true", help="produce as much output as possible")
+    parser.add_argument("--vbr", action="store", type=str, help="Set the variable bitrate for NVENC pass")
+    parser.add_argument("--minrate", action="store", type=str, help="Set the minimum bitrate for NVENC pass")
+    parser.add_argument("--maxrate", action="store", type=str, help="Set the maximum bitrate for NVENC pass")
 
     args = parser.parse_args()
 
@@ -62,6 +66,10 @@ def main():
 
     if args.list_paths:
         print(library.listPaths())
+        sys.exit()
+
+    if args.list_blacklist_paths:
+        print(library.listBlacklistPaths())
         sys.exit()
 
     if args.track:
@@ -131,11 +139,17 @@ def main():
             preset = args.preset.lower()
             if preset in validPresets:
                 if args.nvenc and args.preset.lower() not in nvencPresets:
-                    log.error("invalid nvenc preset passed with nvenc selected")
+                    log.error("invalid nvenc preset passed with nvenc selected, please use fast, medium, or slow")
                     sys.exit()
                 encoder.preset = preset
             else:
                 raise ValueError("preset not a valid argument, please use ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow or placebo")
+        if args.vbr:
+            encoder.vbr = args.vbr
+            if args.minrate:
+                encoder.minrate = args.minrate
+            if args.maxrate:
+                encoder.maxrate = args.maxrate
 
         try:
             encodeResult = encoder.encode()

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ def main():
     parser = argparse.ArgumentParser(description=scriptDescription, allow_abbrev=False)
 
     parser.add_argument("--crf", action="store", metavar="int", type=int,
-        help="CRF parameter to be passed through to ffmpeg, determines quality and speed with lower values being slower but higher quality")
+        help="CRF parameter to be passed through to ffmpeg, determines quality and speed with lower values being slower but higher quality (not for NVENC)")
     parser.add_argument("--errors", "-e", action="store_true", help="list errors")
     parser.add_argument("--database", action="store", help="name of database to be used")
     parser.add_argument("--focus", "-f", action="append", metavar="PATH", help="immediately begin conversion on target directory")
@@ -29,7 +29,7 @@ def main():
     parser.add_argument("--low-profile", action="store_true", help="for weaker devices, convert to 4-bit HEVC including downgrading 10-bit hevc", default=False)
     parser.add_argument("--number", "-n", action="store", help="transcode from tracked paths limit number of files to be converted", type=int)
     parser.add_argument("--nvenc", action="store_true", help="transcode using NVENC compatible GPU")
-    parser.add_argument("--resolution", action="store", type=int, help="output resolution to be used for conversion")
+    parser.add_argument("--resolution", action="store", type=int, help="Height of the output resolution to be used for conversion")
     parser.add_argument("--preset", action="store", type=str,
         help="string for ffmpeg paramater, accepts ultrafast, superfast, veryfast, faster, fast, medium, slow, slower,\
              veryslow and placebo, slower speeds have a higher filesize and better quality")
@@ -38,9 +38,9 @@ def main():
     parser.add_argument("--scan", "-s", action="store_true", help="scan tracked directories for new files")
     parser.add_argument("--quiet", "-q", action="store_true", help="only produce minimal output")
     parser.add_argument("--verbose", "-v", action="store_true", help="produce as much output as possible")
-    parser.add_argument("--vbr", action="store", type=str, help="Set the variable bitrate for NVENC pass")
-    parser.add_argument("--minrate", action="store", type=str, help="Set the minimum bitrate for NVENC pass")
-    parser.add_argument("--maxrate", action="store", type=str, help="Set the maximum bitrate for NVENC pass")
+    parser.add_argument("--vbr", action="store", type=str, help="Set the Variable Bitrate for the encoding pass, this will adjust NVENC quality")
+    parser.add_argument("--minrate", action="store", type=str, help="Set the minimum rate for Variable Bitrate mode")
+    parser.add_argument("--maxrate", action="store", type=str, help="Set the maximum rate for Variable Bitrate mode")
 
     args = parser.parse_args()
 

--- a/main.py
+++ b/main.py
@@ -45,7 +45,14 @@ def main():
     parser.add_argument("--maxrate", action="store", type=str, help="Set the maximum rate for Variable Bitrate mode")
     parser.add_argument("--rate-threshold", action="store", type=int, help="Set the minimum kbps files must have in order to add to processing list during scan")
     parser.add_argument("--rate-ceiling", action="store", type=int, help="Set the maximum kbps files can have in order to add to processing list during scan")
+    parser.add_argument("--height-threshold", action="store", type=int, help="Set the minimum height files must have in order to add to processing list during scan")
+    parser.add_argument("--height-ceiling", action="store", type=int, help="Set the maximum height files can have in order to add to processing list during scan")
     parser.add_argument("--force-encode", action="store_true", help="force HEVC re-encode")
+    parser.add_argument("--clear-all", action="store_true", help="clear the library of all files")
+    parser.add_argument("--clear-skipped", action="store_true", help="clear the library of skipped files")
+    parser.add_argument("--clear-incomplete", action="store_true", help="clear the library of incomplete files")
+    parser.add_argument("--clear-complete", action="store_true", help="clear the library of complete files")
+    parser.add_argument("--clear-failed", action="store_true", help="clear the library of failed files")
 
     args = parser.parse_args()
 
@@ -74,6 +81,12 @@ def main():
     if args.rate_ceiling:
         library.rate_ceiling = args.rate_ceiling
 
+    if args.height_threshold:
+        library.height_threshold = args.height_threshold
+
+    if args.height_ceiling:
+        library.height_ceiling = args.height_ceiling
+
     if args.low_profile:
         library.low_profile = True
 
@@ -90,6 +103,31 @@ def main():
 
     if args.list_blacklist_paths:
         print(library.listBlacklistPaths())
+        sys.exit()
+
+    if args.clear_all:
+        library.clearAll()
+        print('All file lists have been cleared')
+        sys.exit()
+
+    if args.clear_skipped:
+        library.clearSkipped()
+        print('Skipped file list has been cleared')
+        sys.exit()
+
+    if args.clear_incomplete:
+        library.clearIncomplete()
+        print('Incomplete file list has been cleared')
+        sys.exit()
+
+    if args.clear_complete:
+        library.clearComplete()
+        print('Complete file list has been cleared')
+        sys.exit()
+
+    if args.clear_failed:
+        library.clearFailed()
+        print('Failed file list has been cleared')
         sys.exit()
 
     if args.track:

--- a/main.py
+++ b/main.py
@@ -38,6 +38,9 @@ def main():
     parser.add_argument("--scan", "-s", action="store_true", help="scan tracked directories for new files")
     parser.add_argument("--quiet", "-q", action="store_true", help="only produce minimal output")
     parser.add_argument("--verbose", "-v", action="store_true", help="produce as much output as possible")
+    parser.add_argument("--vbr", action="store", type=str, help="Set the variable bitrate for NVENC pass")
+    parser.add_argument("--minrate", action="store", type=str, help="Set the minimum bitrate for NVENC pass")
+    parser.add_argument("--maxrate", action="store", type=str, help="Set the maximum bitrate for NVENC pass")
 
     args = parser.parse_args()
 
@@ -147,7 +150,13 @@ def main():
                 raise ValueError("preset not a valid argument, please use ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow or placebo")
         if args.resolution:
             encoder.resolution = args.resolution
-
+        if args.vbr:
+            encoder.vbr = args.vbr
+            if args.minrate:
+                encoder.minrate = args.minrate
+            if args.maxrate:
+                encoder.maxrate = args.maxrate
+            
         try:
             encodeResult = encoder.encode()
         except videoEncoder.AlreadyEncodedError:


### PR DESCRIPTION
I have added a bit more of settings that allow you to filter the items added to the incomplete files list. This will allow for more selective processing of a large collection of files. This can help when the folder in question is a mixed source of media, with various bitrates and resolutions.

I also added some ways to clear the file lists from within the script itself, instead of doing it manually with the JSON file itself. But if editing the JSON, I also adjusted the output to be human readable for easier adjustments.

Then lastly there is the addition of the VBR adjustment for use with NVENC, which is not affected by the CRF setting. So you can selectively files within a specified range of height and bitrate, then batch encode them to a specific VBR. 

I fixed the issue with the log not respecting its passed options, although it is not pretty... I just shoved the args into the passed parameters where it was needed. But now it will show the debug messages when the user passes -v.